### PR TITLE
fix: TypeScript v6 対応のため tsconfig を修正

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,14 +2,16 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
+    "moduleResolution": "node10",
     "lib": ["ESNext", "esnext.AsyncIterable"],
     "outDir": "./dist",
+    "rootDir": "./src",
     "removeComments": true,
     "esModuleInterop": true,
     "allowJs": true,
     "checkJs": true,
     "incremental": true,
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
     "sourceMap": true,
     "declaration": true,
     "declarationMap": true,
@@ -22,11 +24,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
     "newLine": "LF",
-    "paths": {
-      "@/*": ["src/*"]
-    }
+    "types": ["jest", "node"]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## 概要

TypeScript v6.0 の破壊的変更に追随できるよう、`tsconfig.json` を将来互換な構成に整理します。Renovate PR #2142 (`renovate/typescript-6.x`) が TypeScript 6.x へアップグレードした際に、追加のビルドエラー対応を不要にすることが目的です。

本 PR は master の TypeScript 5.9.3 でも `lint` / `compile:test` / `test` がパスすることをローカルで確認済みです。

## 変更内容

- `moduleResolution: "Node"` → `"node10"` に変更（TS5107 対応／TS v6 でも有効な正規表記）
- `rootDir: "./src"` を追加（TS5011 対応／出力ディレクトリ構造の安定化）
- `tsBuildInfoFile: "./dist/.tsbuildinfo"` を追加（インクリメンタルビルド情報の出力先を明示）
- 未使用の `baseUrl: "."` を削除（TS5101 対応）
- 未使用の `paths` を削除（`baseUrl` 削除に伴い不要、`src/` 配下で `@/*` インポートを使用していないことを確認済み）
- `types: ["jest", "node"]` を追加（TypeScript v6 で `@types/*` の自動解決が変更されたため、テストの `jest` グローバルや Node 型を明示）

## 補足

- `ignoreDeprecations: "6.0"` は **追加していません**。master の TypeScript は 5.9.3 であり、TS 5.x では `"6.0"` は無効値のためビルドエラーになります。`moduleResolution: "node10"` への変更により非推奨警告自体が出ないため、TS 6.x 移行時にも追加は不要です（必要になった場合は Renovate PR 側で対応）。
- 本 PR は Renovate PR #2142 とは独立しています。先に master に取り込むことで、TypeScript 6.x アップグレード PR の差分を最小化できます。

## 検証

ローカルで以下を実行し、いずれもエラーなく完了することを確認しました。

- `pnpm install`
- `pnpm run lint`（prettier + eslint + tsc）
- `pnpm run compile:test`（`tsc -p . --noEmit`）
- `pnpm run test`（jest、14 件すべて pass）