### PR TITLE
fix: Renovateによるbook000 reusable workflowのdigest再固定を戻す

### DIFF
--- a/.github/workflows/add-reviewer.yml
+++ b/.github/workflows/add-reviewer.yml
@@ -12,4 +12,4 @@ on:
 jobs:
   add-reviewer:
     name: Add reviewer
-    uses: book000/templates/.github/workflows/reusable-add-reviewer.yml@13569b86d442904bbc30a3b330e6a8f88b2d7191 # master
+    uses: book000/templates/.github/workflows/reusable-add-reviewer.yml@master

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -78,7 +78,7 @@ jobs:
     name: Docker CI
     needs: approval-gate
     if: always() && needs.approval-gate.result == 'success' && (github.event.action != 'closed' || github.event.pull_request.merged == true)
-    uses: book000/templates/.github/workflows/reusable-docker.yml@13569b86d442904bbc30a3b330e6a8f88b2d7191 # master
+    uses: book000/templates/.github/workflows/reusable-docker.yml@master
     with:
       targets: >-
         [

--- a/.github/workflows/hadolint-ci.yml
+++ b/.github/workflows/hadolint-ci.yml
@@ -13,4 +13,4 @@ on:
 jobs:
   hadolint:
     name: hadolint
-    uses: book000/templates/.github/workflows/reusable-hadolint-ci.yml@13569b86d442904bbc30a3b330e6a8f88b2d7191 # master
+    uses: book000/templates/.github/workflows/reusable-hadolint-ci.yml@master

--- a/.github/workflows/nodejs-ci-pnpm.yml
+++ b/.github/workflows/nodejs-ci-pnpm.yml
@@ -15,4 +15,4 @@ on:
 jobs:
   node-ci:
     name: Node CI
-    uses: book000/templates/.github/workflows/reusable-nodejs-ci-pnpm.yml@13569b86d442904bbc30a3b330e6a8f88b2d7191 # master
+    uses: book000/templates/.github/workflows/reusable-nodejs-ci-pnpm.yml@master


### PR DESCRIPTION
## 概要

book000/book000#124 のロールアウト対応(本リポジトリでは既にマージ済み)で `@master` に変更した箇所が、book000/templates 側の Renovate 設定の不備(book000/templates#432 の実装漏れ)により、Renovate bot によって再度 digest 固定へ巻き戻されていました。

book000/templates#434 で Renovate 側の設定(`pinDigests: false`)は修正済みのため、今後は再発しません。本 PR は巻き戻ってしまった箇所を再度 `@master` に戻すものです。

## 変更内容

- `uses: book000/templates/.github/workflows/reusable-*.yml@<digest>` を `@master` に変更

## 検証

- `python3 -c "import yaml; yaml.safe_load(...)"` で全対象ファイルの YAML 構文を確認

## 関連

- book000/book000#124
- book000/templates#432 (Renovate 設定不備の Issue)
- book000/templates#434 (Renovate 設定修正 PR)