### PR TITLE
fix: eslint-plugin-unicorn(v71) 新規ルール違反を解消

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,11 +1,11 @@
-import { Configuration } from './config'
+import { Config } from './config'
 import fs from 'node:fs'
 
 // テスト用サブクラスでconfigを書き換え可能にする
-class TestConfiguration extends Configuration {
-  public setConfig(obj: any) {
+class TestConfig extends Config {
+  public setConfig(object: any) {
     // @ts-expect-error テスト用にprivateを書き換え
-    this.config = obj
+    this.config = object
   }
 }
 
@@ -19,25 +19,25 @@ describe('Configuration', () => {
   })
 
   it('discord.tokenが正しい場合にvalidate()がtrue', () => {
-    const config = new TestConfiguration(dummyPath)
+    const config = new TestConfig(dummyPath)
     config.setConfig({ discord: { token: 'token' } })
     expect(config.validate()).toBe(true)
   })
 
   it('discordが未設定の場合にvalidate()がfalse', () => {
-    const config = new TestConfiguration(dummyPath)
+    const config = new TestConfig(dummyPath)
     config.setConfig({})
     expect(config.validate()).toBe(false)
   })
 
   it('discord.tokenが未設定の場合にvalidate()がfalse', () => {
-    const config = new TestConfiguration(dummyPath)
+    const config = new TestConfig(dummyPath)
     config.setConfig({ discord: {} })
     expect(config.validate()).toBe(false)
   })
 
   it('discord.tokenがstring以外の場合にvalidate()がfalse', () => {
-    const config = new TestConfiguration(dummyPath)
+    const config = new TestConfig(dummyPath)
     config.setConfig({ discord: { token: 123 } })
     expect(config.validate()).toBe(false)
   })

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ export interface ConfigInterface {
   }
 }
 
-export class Configuration extends ConfigFramework<ConfigInterface> {
+export class Config extends ConfigFramework<ConfigInterface> {
   protected validates(): Record<string, (config: ConfigInterface) => boolean> {
     return {
       'discord is required': (config) => !!config.discord,

--- a/src/discord.ts
+++ b/src/discord.ts
@@ -1,18 +1,24 @@
-import { Client, GatewayIntentBits, Partials } from 'discord.js'
+import {
+  Client,
+  GatewayIntentBits,
+  Guild,
+  GuildMember,
+  Partials,
+} from 'discord.js'
 import { Logger } from '@book000/node-utils'
-import { Configuration } from './config'
-import { Linking } from './linking'
+import { Config } from './config'
+import { Linking, LinkGuild, LinkRole } from './linking'
 import { setInterval } from 'node:timers/promises'
 
 export type RoleUsers = Record<string, string[] | undefined>
 
 export class Discord {
-  private config: Configuration
+  private config: Config
   public readonly client: Client
 
-  constructor(config: Configuration) {
+  constructor(config: Config) {
     const logger = Logger.configure('Discord.constructor')
-    this.client = new Client({
+    const client = new Client({
       intents: [
         GatewayIntentBits.Guilds,
         GatewayIntentBits.GuildMessages,
@@ -21,17 +27,26 @@ export class Discord {
       ],
       partials: [Partials.Message, Partials.Channel, Partials.User],
     })
-    this.client.on('ready', () => {
-      this.onReady().catch((error: unknown) => {
-        logger.error('Error', error as Error)
-      })
+    this.client = client
+    client.on('ready', () => {
+      ;(async () => {
+        try {
+          await this.onReady()
+        } catch (error) {
+          logger.error('Error', error as Error)
+        }
+      })()
     })
 
     this.config = config
 
-    this.client.login(config.get('discord').token).catch((error: unknown) => {
-      logger.error('Error', error as Error)
-    })
+    ;(async () => {
+      try {
+        await client.login(config.get('discord').token)
+      } catch (error) {
+        logger.error('Error', error as Error)
+      }
+    })()
   }
 
   /**
@@ -53,20 +68,36 @@ export class Discord {
     const members = await sourceGuild.members.fetch()
     for (const member of members.values()) {
       logger.info(`🔄 Processing member: ${member.user.tag}`)
-      for (const role of roles) {
-        if (!member.roles.cache.has(role.roleId)) {
-          continue
-        }
-        logger.info(`✨ Member ${member.user.tag} has role ${role.type}`)
-        if (role.type in roleUsers && roleUsers[role.type]) {
-          roleUsers[role.type]?.push(member.id)
-        } else {
-          roleUsers[role.type] = [member.id]
-        }
-      }
+      this.collectMemberRoles(member, roles, roleUsers)
     }
 
     return roleUsers
+  }
+
+  /**
+   * メンバーが保持しているロールを roleUsers に集約する
+   *
+   * @param member 対象メンバー
+   * @param roles ソースサーバのロール設定一覧
+   * @param roleUsers 集約先の RoleUsers
+   */
+  private collectMemberRoles(
+    member: GuildMember,
+    roles: LinkRole[],
+    roleUsers: RoleUsers
+  ): void {
+    const logger = Logger.configure('Linking.collectMemberRoles')
+    for (const role of roles) {
+      if (!member.roles.cache.has(role.roleId)) {
+        continue
+      }
+      logger.info(`✨ Member ${member.user.tag} has role ${role.type}`)
+      if (Object.hasOwn(roleUsers, role.type)) {
+        roleUsers[role.type]?.push(member.id)
+      } else {
+        roleUsers[role.type] = [member.id]
+      }
+    }
   }
 
   /**
@@ -87,32 +118,50 @@ export class Discord {
       logger.info(`🔍 Fetching members of guild ${guildId}`)
       const members = await guild.members.fetch()
       for (const member of members.values()) {
-        for (const roleConfig of guildConfig.roles) {
-          logger.info(
-            `🔄 Processing member: ${member.user.tag} <- ${roleConfig.type}`
-          )
-          if (!roleUsers[roleConfig.type]) {
-            continue
-          }
-          if (
-            roleUsers[roleConfig.type]?.includes(member.id) &&
-            !member.roles.cache.has(roleConfig.roleId)
-          ) {
-            logger.info(
-              `✨ ${member.user.tag} give ${roleConfig.type} in ${guild.name}`
-            )
-            await member.roles.add(roleConfig.roleId)
-          }
-          if (
-            !roleUsers[roleConfig.type]?.includes(member.id) &&
-            member.roles.cache.has(roleConfig.roleId)
-          ) {
-            logger.info(
-              `🚫 ${member.user.tag} take ${roleConfig.type} in ${guild.name}`
-            )
-            await member.roles.remove(roleConfig.roleId)
-          }
-        }
+        await this.syncMemberRoles(member, guild, guildConfig, roleUsers)
+      }
+    }
+  }
+
+  /**
+   * メンバーに対して宛先サーバのロール設定一覧を反映する
+   *
+   * @param member 対象メンバー
+   * @param guild 宛先サーバ
+   * @param guildConfig 宛先サーバのロール設定
+   * @param roleUsers ソースサーバで集約した RoleUsers
+   */
+  private async syncMemberRoles(
+    member: GuildMember,
+    guild: Guild,
+    guildConfig: LinkGuild,
+    roleUsers: RoleUsers
+  ): Promise<void> {
+    const logger = Logger.configure('Linking.syncMemberRoles')
+    for (const roleConfig of guildConfig.roles) {
+      logger.info(
+        `🔄 Processing member: ${member.user.tag} <- ${roleConfig.type}`
+      )
+      if (!Object.hasOwn(roleUsers, roleConfig.type)) {
+        continue
+      }
+      if (
+        roleUsers[roleConfig.type]?.includes(member.id) &&
+        !member.roles.cache.has(roleConfig.roleId)
+      ) {
+        logger.info(
+          `✨ ${member.user.tag} give ${roleConfig.type} in ${guild.name}`
+        )
+        await member.roles.add(roleConfig.roleId)
+      }
+      if (
+        !roleUsers[roleConfig.type]?.includes(member.id) &&
+        member.roles.cache.has(roleConfig.roleId)
+      ) {
+        logger.info(
+          `🚫 ${member.user.tag} take ${roleConfig.type} in ${guild.name}`
+        )
+        await member.roles.remove(roleConfig.roleId)
       }
     }
   }
@@ -135,8 +184,9 @@ export class Discord {
 
     // 10分ごとにロールを同期
     await this.sync()
+    const syncInterval = setInterval(10 * 60 * 1000)
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    for await (const _ of setInterval(10 * 60 * 1000)) {
+    for await (const _ of syncInterval) {
       await this.sync()
     }
   }

--- a/src/linking.test.ts
+++ b/src/linking.test.ts
@@ -7,15 +7,15 @@ describe('Linking', () => {
     sourceGuild: { guildId: 'src', roles: [{ type: 'admin', roleId: '1' }] },
     destGuilds: [{ guildId: 'dst', roles: [{ type: 'admin', roleId: '2' }] }],
   }
-  const tempPath = 'temp-linking.yml'
+  const temporaryPath = 'temp-linking.yml'
 
   afterEach(() => {
-    if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath)
+    if (fs.existsSync(temporaryPath)) fs.unlinkSync(temporaryPath)
   })
 
   it('存在するYAMLファイルを読み込んだ場合、正しくパース・バリデーションされる', () => {
-    fs.writeFileSync(tempPath, yaml.dump(validData))
-    const linking = new Linking(tempPath)
+    fs.writeFileSync(temporaryPath, yaml.dump(validData))
+    const linking = new Linking(temporaryPath)
     expect(linking.getSourceGuild().guildId).toBe('src')
     expect(linking.getDestGuilds().length).toBe(1)
   })
@@ -27,8 +27,8 @@ describe('Linking', () => {
   })
 
   it('YAMLが不正な場合に例外', () => {
-    fs.writeFileSync(tempPath, 'invalid: [')
-    expect(() => new Linking(tempPath)).toThrow()
+    fs.writeFileSync(temporaryPath, 'invalid: [')
+    expect(() => new Linking(temporaryPath)).toThrow()
   })
 
   it('バリデーション失敗時に例外（rolesが空配列）', () => {
@@ -36,8 +36,8 @@ describe('Linking', () => {
       ...validData,
       sourceGuild: { ...validData.sourceGuild, roles: undefined },
     }
-    fs.writeFileSync(tempPath, yaml.dump(invalid))
-    expect(() => new Linking(tempPath)).toThrow()
+    fs.writeFileSync(temporaryPath, yaml.dump(invalid))
+    expect(() => new Linking(temporaryPath)).toThrow()
   })
 
   it('rolesやdestGuildsが空配列の場合もバリデーション成功', () => {
@@ -46,8 +46,8 @@ describe('Linking', () => {
       sourceGuild: { ...validData.sourceGuild, roles: [] },
       destGuilds: [],
     }
-    fs.writeFileSync(tempPath, yaml.dump(data))
-    const linking = new Linking(tempPath)
+    fs.writeFileSync(temporaryPath, yaml.dump(data))
+    const linking = new Linking(temporaryPath)
     expect(Array.isArray(linking.getSourceGuild().roles)).toBe(true)
     expect(Array.isArray(linking.getDestGuilds())).toBe(true)
   })

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,10 @@
 import { Logger } from '@book000/node-utils'
-import { Configuration } from './config'
+import { Config } from './config'
 import { Discord } from './discord'
 
 function main() {
   const logger = Logger.configure('main')
-  const config = new Configuration('data/config.json')
+  const config = new Config('data/config.json')
   config.load()
   if (!config.validate()) {
     logger.error('❌ Configuration is invalid')
@@ -19,16 +19,16 @@ function main() {
   const discord = new Discord(config)
   process.once('SIGINT', () => {
     logger.info('👋 SIGINT signal received.')
-    discord
-      .close()
-      .then(() => {
+    ;(async () => {
+      try {
+        await discord.close()
         logger.info('🤖 Stopped tomachi-emojis-sync-perms')
         process.exit(0)
-      })
-      .catch((error: unknown) => {
+      } catch (error) {
         logger.error('Error', error as Error)
         process.exit(1)
-      })
+      }
+    })()
   })
 
   // uncaughtExceptionの場合にも終了処理を行う


### PR DESCRIPTION
## 概要

Renovate PR #2333 (`@book000/eslint-config` 1.15.4 -> 1.15.44) が CI 失敗中のため、その原因となっている既存コードの lint エラーを個別に修正する。

## 原因

`@book000/eslint-config` の更新に伴い `eslint-plugin-unicorn` が新しくなり、これまで検出されていなかった 17 件の既存コードの unicorn ルール違反が新たに検出されるようになった (該当ルール: `unicorn/name-replacements`, `unicorn/prefer-await`, `unicorn/no-break-in-nested-loop`, `unicorn/no-computed-property-existence-check`, `unicorn/no-unreadable-for-of-expression`)。

## 変更内容

- `unicorn/name-replacements`: `Configuration` -> `Config` にクラス名変更 (関連する自動修正も反映)
- `unicorn/prefer-await`: `.then()`/`.catch()` チェーンを `await`/`try-catch` に変更。非 async なコールバック内 (constructor、SIGINT ハンドラ) は async IIFE でラップ
- `unicorn/no-break-in-nested-loop`: ネストしたループ内の `continue` をヘルパーメソッド (`collectMemberRoles`, `syncMemberRoles`) へ切り出し
- `unicorn/no-computed-property-existence-check`: `Object.hasOwn()` を使用
- `unicorn/no-unreadable-for-of-expression`: `for await...of` のヘッダから複雑な式を変数へ切り出し

このブランチでは `@book000/eslint-config` 自体のバージョンは変更していない (Renovate PR #2333 側の担当)。ローカルで 1.15.4 (現行) / 1.15.44 (Renovate PR の対象バージョン) 両方の下で `pnpm run lint` (prettier+eslint+tsc) と `pnpm test` が通ることを確認済み。

Related: #2333
