### PR TITLE
chore: .worktreeinclude を追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+data/config.json
+data/linking.yml
+data/


### PR DESCRIPTION
## 概要

`git worktree` 作成時にローカル設定ファイル（Discord Bot トークンやロール同期設定）が新しい worktree に引き継がれない問題に対応するため、`.worktreeinclude` を追加した。

## 追加したパターン

```
data/config.json
data/linking.yml
data/
```

## 根拠

- `.gitignore` の `# other` セクションに `data/` が含まれている（Git 管理外）
- `src/main.ts:7` で `new Configuration('data/config.json')` を使用
- `src/discord.ts:149` で `process.env.LINKING_PATH ?? 'data/linking.yml'` を使用
- `Dockerfile` は `ENV CONFIG_PATH=/data/config.json` および `ENV LINKING_PATH=/data/linking.yml` を設定
- `README.md` の「設定」セクション: `data/config.json` に Discord Bot トークン（`{"discord": {"token": "your-discord-bot-token"}}`）、`data/linking.yml` にロール同期設定を保持
- `README.md` の Docker セクション: 「Docker で実行する場合は、設定ファイルをコンテナにマウントする必要があります」との記載があり、`compose.yaml` で `./data/config.json` と `./data/linking.yml` をバインドする想定

なお、リポジトリルートの `compose.yaml` は `./config.yml` をバインドしており README・ソースコードが参照する `data/config.json` / `data/linking.yml` と不整合があるが、これは本 PR のスコープ外の既存の問題であり修正しない。

`.env.example` や設定テンプレートファイルがリポジトリに含まれていないため、`.worktreeinclude` がない状態では新規 worktree ごとに Discord Bot トークンファイルとロール同期設定ファイルを手動で再作成する必要がある。

## 関連

https://github.com/book000/book000/issues/132
